### PR TITLE
fix: Broken curl error handling

### DIFF
--- a/src/PrefillGravityForms/Controllers/BaseController.php
+++ b/src/PrefillGravityForms/Controllers/BaseController.php
@@ -369,7 +369,7 @@ abstract class BaseController
             $httpStatus = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 
             if (200 !== $httpStatus) {
-                throw new Exception(sprintf('%s', $decoded['detail'] ?? ($decoded['Error Details'] ?? 'Request failed, error unknown')), is_int($httpStatus) ? $httpStatus : 500);
+                throw new Exception("Unexpected HTTP status. Response: $output", is_int($httpStatus) ? $httpStatus : 500);
             }
 
             $this->handleTransient($response, $transientKey, $locationBsnInResponse);


### PR DESCRIPTION
It looks like the JSON responses can differ depending on the resource that is fetched. Use a more generic approach to capture proper error messages.